### PR TITLE
Update Taskwarrior plugin:

### DIFF
--- a/plugins/taskwarrior/taskwarrior.plugin.zsh
+++ b/plugins/taskwarrior/taskwarrior.plugin.zsh
@@ -4,4 +4,4 @@ zstyle ':completion:*:*:task:*:descriptions' format '%U%B%d%b%u'
 zstyle ':completion:*:*:task:*' group-name ''
 
 alias t=task
-compdef _task t=task
+compdef _task t,task


### PR DESCRIPTION
autocompletitions don't work  due to a mistake of compdef command

Closes #3796